### PR TITLE
fix ternary, fix settings & reorder replace

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,9 +3,7 @@ const { get } = require('powercord/http')
 
 module.exports = class e621 extends Plugin {
     startPlugin() {
-        const userAgent = this.settings.get("headers", "Powercord/1.0 (<e621username>)")
-        const nsfw = this.settings.get("nsfw", false)
-        const blacklistedTags = this.settings.get("blacklistedTags", "")
+        var plugin = this
         powercord.api.settings.registerSettings("e621", {
             category: this.entityID,
             label: "e621",
@@ -26,6 +24,9 @@ module.exports = class e621 extends Plugin {
                     )}\``,
                   }
                 }
+                var userAgent = plugin.settings.get("headers", "Powercord/1.0 (<e621username>)")
+                var nsfw = plugin.settings.get("nsfw", false)
+                var blacklistedTags = plugin.settings.get("blacklistedTags", "")
                 if (userAgent === "Powercord/1.0 (<e621username>)") {
                     return {
                         send: false,
@@ -41,7 +42,7 @@ module.exports = class e621 extends Plugin {
                 } 
                 const post = p.posts[0]
                 async function getPost(tags) {
-                    nsfw ? tags.push("rating:s") : {}
+                    nsfw ? {} : tags.push("rating:s")
                     return await get(`https://${nsfw ? "e621" : "e926"}.net/posts.json?tags=${tags.join('%20')}`)
                     .set("User-Agent", userAgent)
                     .then(r => {return r.body})

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ module.exports = class e621 extends Plugin {
                 } */
                 
                 // let send = `\`\`\`diff\nRequest Debug\n- Blacklisted Tags Applied: ${blTags.length}\n- NSFW? On\n- Extra Tags: \`\`\`\n`
-                let send = `> **Post ID:** ${post.id}\n> **Rating:** ${post.rating.replace("e", "Explicit").replace("q", "Questionable").replace("s", "Safe")}\n> **Post URL:** <https://${nsfw ? "e621" : "e926"}.net/posts/${post.id}>\n> **Image:** ${post.file.url}\n> **Score:** ${post.score.total}`
+                let send = `> **Post ID:** ${post.id}\n> **Rating:** ${post.rating.replace("e", "Explicit").replace("s", "Safe").replace("q", "Questionable")}\n> **Post URL:** <https://${nsfw ? "e621" : "e926"}.net/posts/${post.id}>\n> **Image:** ${post.file.url}\n> **Score:** ${post.score.total}`
                 
                 return {
                     send: false,


### PR DESCRIPTION
1. the ternary operator on line 44 is mis-ordered, making the plugin push the safe option if NSFW is on, which is not correct. in this commit, i've swapped the sides of the ternary operator.
2. the settings change does not apply when the command is entered after changing settings. in this commit, i have assigned the plugin object to a public variable, and made the command grab settings on run.
3. the replace on line 61 causes "Questionable" to become "QueSafetionable", due to the order of the statements. in this commit, i have swapped the places of the "Safe" and "Questionable" replaces to prevent this.

as a ~~fellow~~ furry plugin developer in the powercord server, i will not let this stand